### PR TITLE
support running on a linux vm.  RedirectURL configured at runtime

### DIFF
--- a/oauth2ns.go
+++ b/oauth2ns.go
@@ -18,8 +18,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-const serverWaitTimeout = 40 * time.Second
-
 type AuthorizedClient struct {
 	*http.Client
 	Token *oauth2.Token
@@ -29,6 +27,7 @@ const (
 	// PORT is the port that the temporary oauth server will listen on
 	PORT                       = 14565
 	oauthStateStringContextKey = 987
+	serverWaitTimeout = 40 * time.Second
 )
 
 type AuthenticateUserOption func(*AuthenticateUserFuncConfig) error
@@ -114,7 +113,6 @@ func startHTTPServer(ctx context.Context, conf *oauth2.Config) (clientChan chan 
 	cancelAuthentication = make(chan struct{})
 
 	http.HandleFunc("/oauth/callback", callbackHandler(ctx, conf, clientChan))
-	// TOOD server listen on external address
 	srv := &http.Server{Addr: ":" + strconv.Itoa(PORT)}
 
 	// handle server shutdown signal

--- a/oauth2ns.go
+++ b/oauth2ns.go
@@ -14,7 +14,6 @@ import (
 	"github.com/fatih/color"
 	rndm "github.com/nmrshll/rndm-go"
 	"github.com/palantir/stacktrace"
-	"github.com/skratchdot/open-golang/open"
 	"golang.org/x/oauth2"
 )
 
@@ -84,17 +83,23 @@ func AuthenticateUser(oauthConfig *oauth2.Config, options ...AuthenticateUserOpt
 
 	clientChan, stopHTTPServerChan, cancelAuthentication := startHTTPServer(ctx, oauthConfig)
 	log.Println(color.CyanString("You will now be taken to your browser for authentication"))
+	// TODO DONE login without prompting browser window
 	time.Sleep(1000 * time.Millisecond)
-	err := open.Run(urlString)
-	if err != nil {
-		return nil, stacktrace.Propagate(err, "failed opening browser window")
-	}
+	//err := open.Run(urlString)
+	log.Printf("Open your browser to: %s", urlString)
+	/*
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "failed opening browser window")
+		}
+	*/
 	time.Sleep(600 * time.Millisecond)
 
 	// shutdown the server after 10 seconds
 	go func() {
-		spew.Dump("authentication will be cancelled in 40 seconds")
-		time.Sleep(40 * time.Second)
+		serverWaitTimeout := 60 * 5 * time.Second
+		spew.Dump(fmt.Sprintf("authentication will be cancelled in %s seconds", serverWaitTimeout))
+		// add comment
+		time.Sleep(serverWaitTimeout)
 		stopHTTPServerChan <- struct{}{}
 	}()
 
@@ -118,6 +123,7 @@ func startHTTPServer(ctx context.Context, conf *oauth2.Config) (clientChan chan 
 	cancelAuthentication = make(chan struct{})
 
 	http.HandleFunc("/oauth/callback", callbackHandler(ctx, conf, clientChan))
+	// TOOD server listen on external address
 	srv := &http.Server{Addr: ":" + strconv.Itoa(PORT)}
 
 	// handle server shutdown signal


### PR DESCRIPTION
* use `oauthConfig.RedirectURL` as passed from caller -- it can be set in the `config.hjson`. Uses previous literal as default in `gphotos-uploader-cli`
* minor cleanup for timeout on L104