### PR TITLE
Stop browser blocking server

### DIFF
--- a/oauth2ns.go
+++ b/oauth2ns.go
@@ -96,7 +96,7 @@ func AuthenticateUser(oauthConfig *oauth2.Config, options ...AuthenticateUserOpt
 	log.Println(color.CyanString(urlString))
 	log.Println(color.CyanString("If you are opening the url manually on a different machine you will need to curl the result url on this machine manually."))
 	time.Sleep(1000 * time.Millisecond)
-	err := open.Run(urlString)
+	err := open.Start(urlString)
 	if err != nil {
 		log.Println(color.RedString("Failed to open browser, you MUST do the manual process."))
 	}


### PR DESCRIPTION
Don't wait for the web browser to terminate, otherwise it tries to contact a server running under the process which is waiting for the browser to exit.