### PR TITLE
Request user consent to get a refresh token

### DIFF
--- a/oauth2ns.go
+++ b/oauth2ns.go
@@ -72,7 +72,8 @@ func AuthenticateUser(oauthConfig *oauth2.Config, options ...AuthenticateUserOpt
 	// Some random string, random for each request
 	oauthStateString := rndm.String(8)
 	ctx = context.WithValue(ctx, oauthStateStringContextKey, oauthStateString)
-	urlString := oauthConfig.AuthCodeURL(oauthStateString, oauth2.AccessTypeOffline)
+	// Getting consent from the user is required to get a refresh token
+	urlString := oauthConfig.AuthCodeURL(oauthStateString, oauth2.AccessTypeOffline, oauth2.ApprovalForce)
 
 	if optionsConfig.AuthCallHTTPParams != nil {
 		parsedURL, err := url.Parse(urlString)
@@ -174,7 +175,7 @@ func callbackHandler(ctx context.Context, oauthConfig *oauth2.Config, clientChan
 		code := r.FormValue("code")
 		token, err := oauthConfig.Exchange(ctx, code)
 		if err != nil {
-			fmt.Printf("oauthoauthConfig.Exchange() failed with '%s'\n", err)
+			fmt.Printf("oauthConfig.Exchange() failed with '%s'\n", err)
 			http.Redirect(w, r, "/", http.StatusTemporaryRedirect)
 			return
 		}


### PR DESCRIPTION
That's not explicitly stated in the [Google OAuth 2.0 documentation](https://developers.google.com/identity/protocols/OAuth2WebServer#creatingclient) but getting a `refresh token` requires the user's consent.

Without this change, the token stored into the keyring by `googlephotos-uploader-go-api` looks like:

```
# keyring get googlephotos-uploader-go-api p******@g******.***
{"access_token":"ya29.******-Va67Ye2i6TPX_eCo5awriw_Q","token_type":"Bearer","expiry":"2019-06-13T01:42:33.895720618+02:00"}

```

With this change:

```
# keyring get googlephotos-uploader-go-api p******@g******.***
{"access_token":"ya29.******-ImE5lpTrzF8FhSBqktvxtWi","token_type":"Bearer","refresh_token":"1/vyd******RRDE","expiry":"2019-06-13T02:35:01.967502755+02:00"}
```

This allows gphotos-uploader-cli to automatically retrieve a new access token without any browser.

Maybe this can be made into an option if this is not always desired.